### PR TITLE
don't diff children for unrelated subtrees

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -43,12 +43,11 @@ function walk(a, b, patch, index) {
                     apply = appendPatch(apply,
                         new VPatch(VPatch.PROPS, a, propsPatch))
                 }
+                apply = diffChildren(a, b, patch, apply, index)
             } else {
                 apply = appendPatch(apply, new VPatch(VPatch.VNODE, a, b))
                 destroyWidgets(a, patch, index)
             }
-
-            apply = diffChildren(a, b, patch, apply, index)
         } else {
             apply = appendPatch(apply, new VPatch(VPatch.VNODE, a, b))
             destroyWidgets(a, patch, index)


### PR DESCRIPTION
only diff children for VNodes where only the properties are patched.
for nodes with a VPatch.VNODE patch, the children of the patch
VNode will be rendered as part of the patch-op for VPatch.VNODE and so
there is no need to diff the children.

another way to think about this is that if the 2 VNodes aren't similar
enough then one replaces the other and we can skip diffing the children
since the subtrees are assumed to be completely unrelated.

this fixes the failing test added in https://github.com/Matt-Esch/virtual-dom/pull/106
