### PR TITLE
use fresh array/object for children and properties in VNode to allow to alter them later

### DIFF
--- a/vnode.js
+++ b/vnode.js
@@ -5,13 +5,10 @@ var isVHook = require("./is-vhook")
 
 module.exports = VirtualNode
 
-var noProperties = {}
-var noChildren = []
-
 function VirtualNode(tagName, properties, children, key, namespace) {
     this.tagName = tagName
-    this.properties = properties || noProperties
-    this.children = children || noChildren
+    this.properties = properties || {}
+    this.children = children || []
     this.key = key != null ? String(key) : undefined
     this.namespace = (typeof namespace === "string") ? namespace : null
 


### PR DESCRIPTION
In the current implementation of VNode it is not possible to alter children at a later stage because the noChildren array becomes a shared variable between all VNode instances.
When creating a new children array inside the VNode constructor function they are instance variable and not shared.

The following code creates circular references in the current VNode implementation:

``` javascript
var root = new VNode('div', {});
root.children.push(new VNode('span', {}));
```

There are two possible workarounds:
- this pull request
- calling the VNode constructor and providing an empty array as third argument per default:

``` javascript
var root = new VNode('div', {}, []);
root.children.push(new VNode('span', {}));
```
