### PR TITLE
don’t lose the `type` and `version` properties when stringified

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "email": "matt@mattesch.info"
   },
   "dependencies": {
-    "x-is-array": "^0.1.0",
-    "is-object": "^0.1.2"
+    "is-object": "^0.1.2",
+    "object.assign": "^1.0.1",
+    "x-is-array": "^0.1.0"
   },
   "devDependencies": {
     "tape": "^2.13.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "matt@mattesch.info"
   },
   "dependencies": {
-    "is-object": "^0.1.2",
+    "is-object": "^0.1.0",
     "x-is-array": "^0.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "matt@mattesch.info"
   },
   "dependencies": {
-    "is-object": "^0.1.0",
+    "is-object": "^0.1.2",
     "x-is-array": "^0.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "is-object": "^0.1.2",
-    "object.assign": "^1.0.1",
     "x-is-array": "^0.1.0"
   },
   "devDependencies": {

--- a/vnode.js
+++ b/vnode.js
@@ -2,7 +2,6 @@ var version = require("./version")
 var isVNode = require("./is-vnode")
 var isWidget = require("./is-widget")
 var isVHook = require("./is-vhook")
-var assign = require('object.assign')
 
 module.exports = VirtualNode
 
@@ -10,6 +9,8 @@ var noProperties = {}
 var noChildren = []
 
 function VirtualNode(tagName, properties, children, key, namespace) {
+    this.version = version
+    this.type = "VirtualNode"
     this.tagName = tagName
     this.properties = properties || noProperties
     this.children = children || noChildren
@@ -58,11 +59,4 @@ function VirtualNode(tagName, properties, children, key, namespace) {
     this.hasWidgets = hasWidgets
     this.hooks = hooks
     this.descendantHooks = descendantHooks
-}
-
-VirtualNode.prototype.version = version
-VirtualNode.prototype.type = "VirtualNode"
-
-VirtualNode.prototype.toJSON = function () {
-  return assign({}, this, { version: this.version, type: this.type })
 }

--- a/vnode.js
+++ b/vnode.js
@@ -2,6 +2,7 @@ var version = require("./version")
 var isVNode = require("./is-vnode")
 var isWidget = require("./is-widget")
 var isVHook = require("./is-vhook")
+var assign = require('object.assign')
 
 module.exports = VirtualNode
 
@@ -61,3 +62,7 @@ function VirtualNode(tagName, properties, children, key, namespace) {
 
 VirtualNode.prototype.version = version
 VirtualNode.prototype.type = "VirtualNode"
+
+VirtualNode.prototype.toJSON = function () {
+  return assign({}, this, { version: this.version, type: this.type })
+}

--- a/vpatch.js
+++ b/vpatch.js
@@ -18,5 +18,3 @@ function VirtualPatch(type, vNode, patch) {
     this.vNode = vNode
     this.patch = patch
 }
-
-VirtualPatch.prototype.type = "VirtualPatch"

--- a/vpatch.js
+++ b/vpatch.js
@@ -1,5 +1,4 @@
 var version = require("./version")
-var assign = require('object.assign')
 
 VirtualPatch.NONE = 0
 VirtualPatch.VTEXT = 1
@@ -14,14 +13,10 @@ VirtualPatch.THUNK = 8
 module.exports = VirtualPatch
 
 function VirtualPatch(type, vNode, patch) {
+    this.version = version
     this.type = Number(type)
     this.vNode = vNode
     this.patch = patch
 }
 
-VirtualPatch.prototype.version = version
 VirtualPatch.prototype.type = "VirtualPatch"
-
-VirtualPatch.prototype.toJSON = function () {
-  return assign({}, this, { version: this.version, type: this.type })
-}

--- a/vpatch.js
+++ b/vpatch.js
@@ -1,4 +1,5 @@
 var version = require("./version")
+var assign = require('object.assign')
 
 VirtualPatch.NONE = 0
 VirtualPatch.VTEXT = 1
@@ -20,3 +21,7 @@ function VirtualPatch(type, vNode, patch) {
 
 VirtualPatch.prototype.version = version
 VirtualPatch.prototype.type = "VirtualPatch"
+
+VirtualPatch.prototype.toJSON = function () {
+  return assign({}, this, { version: this.version, type: this.type })
+}

--- a/vtext.js
+++ b/vtext.js
@@ -1,4 +1,5 @@
 var version = require("./version")
+var assign = require('object.assign')
 
 module.exports = VirtualText
 
@@ -8,3 +9,7 @@ function VirtualText(text) {
 
 VirtualText.prototype.version = version
 VirtualText.prototype.type = "VirtualText"
+
+VirtualText.prototype.toJSON = function () {
+  return assign({}, this, { version: this.version, type: this.type })
+}

--- a/vtext.js
+++ b/vtext.js
@@ -1,15 +1,9 @@
 var version = require("./version")
-var assign = require('object.assign')
 
 module.exports = VirtualText
 
 function VirtualText(text) {
+    this.version = version
+    this.type = "VirtualText"
     this.text = String(text)
-}
-
-VirtualText.prototype.version = version
-VirtualText.prototype.type = "VirtualText"
-
-VirtualText.prototype.toJSON = function () {
-  return assign({}, this, { version: this.version, type: this.type })
 }


### PR DESCRIPTION
The `type` and `version` properties of the `VirtualNode`, `VirtualText`and `VirtualPatch` objects are not serialized by `JSON.stringify()` making `vdom.patch()` fail when called with stringified-then-parsed patches.
