### PR TITLE
Thunk indexing

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -175,7 +175,7 @@ function destroyWidgets(vNode, patch, index) {
         if (typeof vNode.destroy === "function") {
             patch[index] = new VPatch(VPatch.REMOVE, vNode, null)
         }
-    } else if (isVNode(vNode) && vNode.hasWidgets) {
+    } else if (isVNode(vNode) && (vNode.hasWidgets || vNode.hasThunks)) {
         var children = vNode.children
         var len = children.length
         for (var i = 0; i < len; i++) {
@@ -188,6 +188,8 @@ function destroyWidgets(vNode, patch, index) {
                 index += child.count
             }
         }
+    } else if (isThunk(vNode)) {
+        thunks(vNode, null, patch, index);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "is-object": "^0.1.2"
   },
   "devDependencies": {
-    "tape": "^2.13.3",
-    "virtual-dom": "0.0.10"
+    "tape": "^3.0.3"
   },
   "licenses": [
     {

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,1 @@
-require("virtual-dom/test")
 require('./handle-thunk.js')

--- a/vnode.js
+++ b/vnode.js
@@ -1,6 +1,7 @@
 var version = require("./version")
 var isVNode = require("./is-vnode")
 var isWidget = require("./is-widget")
+var isThunk = require("./is-thunk")
 var isVHook = require("./is-vhook")
 
 module.exports = VirtualNode
@@ -18,6 +19,7 @@ function VirtualNode(tagName, properties, children, key, namespace) {
     var count = (children && children.length) || 0
     var descendants = 0
     var hasWidgets = false
+    var hasThunks = false
     var descendantHooks = false
     var hooks
 
@@ -43,6 +45,10 @@ function VirtualNode(tagName, properties, children, key, namespace) {
                 hasWidgets = true
             }
 
+            if (!hasThunks && child.hasThunks) {
+                hasThunks = true
+            }
+
             if (!descendantHooks && (child.hooks || child.descendantHooks)) {
                 descendantHooks = true
             }
@@ -50,11 +56,14 @@ function VirtualNode(tagName, properties, children, key, namespace) {
             if (typeof child.destroy === "function") {
                 hasWidgets = true
             }
+        } else if (!hasThunks && isThunk(child)) {
+            hasThunks = true;
         }
     }
 
     this.count = count + descendants
     this.hasWidgets = hasWidgets
+    this.hasThunks = hasThunks
     this.hooks = hooks
     this.descendantHooks = descendantHooks
 }


### PR DESCRIPTION
@neonstalwart I think this is the solution we are looking for to destroying widgets across thunk boundaries. As I mentioned on your PR, evaluation of the thunk before diff defeats the purpose of the thunk, so we need another solution. The two solutions I could think of were:
- Either have thunks state that they will have widgets
- Or assume that thunks might have widgets

The first option seemed like a poor usability point, so I opted for the second, adding a hasThunks key. This also probably helps with debugging and inspection anyway.

While looking over thunks I noticed a bunch of indexing issues with thunks, so please look over this carefully. A follow up diff is coming in vdom to patch the dom indexing logic.

For completeness I also added code to jump the thunk boundary when executing hooks, but note that this behavior will subsequently be removed to favor "soft hooks" for performance.
